### PR TITLE
Configuration.hs: use Data.Map.{Strict,Lazy} for ghc-8.6.3

### DIFF
--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -56,7 +56,8 @@ import Distribution.Types.CondTree
 import Distribution.Types.Condition
 import Distribution.Types.DependencyMap
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map.Strict
+import qualified Data.Map.Lazy as Map
 import Data.Tree ( Tree(Node) )
 
 ------------------------------------------------------------------------------
@@ -219,7 +220,7 @@ resolveWithFlags dom enabled os arch impl constrs trees checkDeps =
     mp m@(Right _) _           = m
     mp _           m@(Right _) = m
     mp (Left xs)   (Left ys)   =
-        let union = Map.foldrWithKey (Map.insertWith' combine)
+        let union = Map.foldrWithKey (Map.Strict.insertWith combine)
                     (unDepMapUnion xs) (unDepMapUnion ys)
             combine x y = simplifyVersionRange $ unionVersionRanges x y
         in union `seq` Left (DepMapUnion union)


### PR DESCRIPTION
Thanks to Sergey Alirzaev for the patch.

I admit that I am unfamiliar with using git submodules such as this one, and whether or not this is the best way forward given upstream has already implemented this change.

This patch continues to allow hackport to build successfully on ghc-8.4.4, and Sergey suggests that this also allows `hackport` to build on ghc-8.6.3.

I tested the resulting `hackport` executable by using the merge command on `pandoc` and `ansi-terminal`. Both seemed to generate correct ebuilds.

Reported-By: Sergey Alirzaev (l29ah)
Bug: https://github.com/gentoo-haskell/hackport/issues/49
Signed-off-by: Jack Todaro <jackmtodaro@gmail.com>